### PR TITLE
Version 1.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,15 @@
-Version 1.0
+Version 1.1
 
-- Fixes #33
-- Version 1.0
-- Updated `README.md` for some clarity
-- Cleaned up `docker-compose.yml` and `Dockerfile` a bit
-- Python to version 3.12 now
-- Removed import and scrubbing CLI utilities
-- Linted
+- Added user-agent detection
+- Fixes #37
+- Deprecated `/report` for `/rides`
+- Removed `/report` from `footer.j2`
+- Removed `/report` from `tests/main_test.py`
+- Updated all directives to return HTML or JSON based on user-agent
+- Added templates for each HTML-based response
+- Fixed trailing slash in URL for `/scrub`
+- Added `push_to_github()` during `/scrub`
+- Fixes #34
+- Sending line longname to `/add_ride`
+- Fixed #38
+- Updated `README.md`

--- a/README.md
+++ b/README.md
@@ -125,10 +125,13 @@ add an application.
 
 ## Templates
 
-- `add_ride.j2`: The output from submitting a ride
+- `add_ride.j2`: The HTML template from submitting a ride
 - `toot.j2`: The format of the Mastodon update
 - `footer.j2`: The same footer for every page shown
-- `ride_report.j2`: The format for the ride report
+- `ride_report.j2`: The HTML template for the ride report
+- `stock_report.j2`: The HTML template for the stock report
+- `scrub.j2`: The HTML template for the scrub reply
+- `lines.j2`: The HTML template for the line report
 
 ## Docker Files
 

--- a/app/templates/footer.j2
+++ b/app/templates/footer.j2
@@ -1,1 +1,1 @@
-<A HREF="/">Home</A> | <A HREF="/rides">All Rides</A> | <A HREF="/lines">All Lines</A> | <A HREF="/report">Report</A> | <A HREF="/scrub">Scrub</A>
+<A HREF="/">Home</A> | <A HREF="/rides">All Rides</A> | <A HREF="/lines">All Lines</A> | <A HREF="/scrub">Scrub</A>

--- a/app/templates/lines.j2
+++ b/app/templates/lines.j2
@@ -48,16 +48,14 @@ table.greyGridTable tfoot td {
             <TABLE class="greyGridTable">
                 <THEAD>
                     <TR>
-                        <TD>Car No</TD>
-                        <TD>Date</TD>
-                        <TD>Line</TD>
+                        <TD>Line Name</TD>
+                        <TD>Line Abbr</TD>
                     </TR>
                 </THEAD>
                 <TBODY>
-            {%- for ride in rides %}<TR>
-                    <TD>{{ ride.car_no}}</TD>
-                    <TD>{{ ride.date }}</TD>
-                    <TD>{{ ride.line }}</TD>
+            {%- for line in lines %}<TR>
+                    <TD>{{ line['longname'] }}</TD>
+                    <TD>{{ line['shortname'] }}</TD>
                 </TR>
                 {% endfor %}</TBODY>
             </TABLE>

--- a/app/templates/rides.j2
+++ b/app/templates/rides.j2
@@ -1,0 +1,66 @@
+<HTML>
+    <HEAD>
+    <STYLE>
+    table.greyGridTable {
+  border: 2px solid #FFFFFF;
+  width: 100%;
+  text-align: center;
+  border-collapse: collapse;
+}
+table.greyGridTable td, table.greyGridTable th {
+  border: 1px solid #FFFFFF;
+  padding: 3px 4px;
+}
+table.greyGridTable tbody td {
+  font-size: 13px;
+}
+table.greyGridTable td:nth-child(even) {
+  background: #EBEBEB;
+}
+table.greyGridTable thead {
+  background: #FFFFFF;
+  border-bottom: 4px solid #333333;
+}
+table.greyGridTable thead th {
+  font-size: 15px;
+  font-weight: bold;
+  color: #333333;
+  text-align: center;
+  border-left: 2px solid #333333;
+}
+table.greyGridTable thead th:first-child {
+  border-left: none;
+}
+
+table.greyGridTable tfoot {
+  font-size: 14px;
+  font-weight: bold;
+  color: #333333;
+  border-top: 4px solid #333333;
+}
+table.greyGridTable tfoot td {
+  font-size: 14px;
+}
+</STYLE>
+    </HEAD>
+
+    <BODY>
+            <TABLE class="greyGridTable">
+                <THEAD>
+                    <TR>
+                        <TD>Car Number</TD>
+                        <TD>Date Ridden</TD>
+                        <TD>Line</TD>
+                    </TR>
+                </THEAD>
+                <TBODY>
+            {%- for ride in rides %}<TR>
+                    <TD>{{ ride['car_no'] }}</TD>
+                    <TD>{{ ride['date'] }}</TD>
+                    <TD>{{ ride['line'] }}</TD>
+                </TR>
+                {% endfor %}</TBODY>
+            </TABLE>
+        {% include "footer.j2" %}
+    </BODY>
+</HTML>

--- a/app/templates/scrub.j2
+++ b/app/templates/scrub.j2
@@ -1,0 +1,63 @@
+<HTML>
+    <HEAD>
+    <STYLE>
+    table.greyGridTable {
+  border: 2px solid #FFFFFF;
+  width: 100%;
+  text-align: center;
+  border-collapse: collapse;
+}
+table.greyGridTable td, table.greyGridTable th {
+  border: 1px solid #FFFFFF;
+  padding: 3px 4px;
+}
+table.greyGridTable tbody td {
+  font-size: 13px;
+}
+table.greyGridTable td:nth-child(even) {
+  background: #EBEBEB;
+}
+table.greyGridTable thead {
+  background: #FFFFFF;
+  border-bottom: 4px solid #333333;
+}
+table.greyGridTable thead th {
+  font-size: 15px;
+  font-weight: bold;
+  color: #333333;
+  text-align: center;
+  border-left: 2px solid #333333;
+}
+table.greyGridTable thead th:first-child {
+  border-left: none;
+}
+
+table.greyGridTable tfoot {
+  font-size: 14px;
+  font-weight: bold;
+  color: #333333;
+  border-top: 4px solid #333333;
+}
+table.greyGridTable tfoot td {
+  font-size: 14px;
+}
+</STYLE>
+    </HEAD>
+
+    <BODY>
+            <TABLE class="greyGridTable">
+                <THEAD>
+                    <TR>
+                        <TD>Valid Records</TD>
+                        <TD>Scrubbed Records</TD>
+                    </TR>
+                </THEAD>
+                <TBODY>
+            <TR>
+                    <TD>{{ valid_count }}</TD>
+                    <TD>{{ scrub_count }}</TD>
+            </TR>
+            </TABLE>
+        {% include "footer.j2" %}
+    </BODY>
+</HTML>

--- a/app/templates/stock_report.j2
+++ b/app/templates/stock_report.j2
@@ -1,0 +1,64 @@
+<HTML>
+    <HEAD>
+    <STYLE>
+    table.greyGridTable {
+  border: 2px solid #FFFFFF;
+  width: 100%;
+  text-align: center;
+  border-collapse: collapse;
+}
+table.greyGridTable td, table.greyGridTable th {
+  border: 1px solid #FFFFFF;
+  padding: 3px 4px;
+}
+table.greyGridTable tbody td {
+  font-size: 13px;
+}
+table.greyGridTable td:nth-child(even) {
+  background: #EBEBEB;
+}
+table.greyGridTable thead {
+  background: #FFFFFF;
+  border-bottom: 4px solid #333333;
+}
+table.greyGridTable thead th {
+  font-size: 15px;
+  font-weight: bold;
+  color: #333333;
+  text-align: center;
+  border-left: 2px solid #333333;
+}
+table.greyGridTable thead th:first-child {
+  border-left: none;
+}
+
+table.greyGridTable tfoot {
+  font-size: 14px;
+  font-weight: bold;
+  color: #333333;
+  border-top: 4px solid #333333;
+}
+table.greyGridTable tfoot td {
+  font-size: 14px;
+}
+</STYLE>
+    </HEAD>
+
+    <BODY>
+            <TABLE class="greyGridTable">
+                <THEAD>
+                    <TR>
+                        <TD>Type</TD>
+                        <TD>Count</TD>
+                    </TR>
+                </THEAD>
+                <TBODY>
+            {%- for count in stock_counts %}<TR>
+                    <TD>{{ count[0] }}</TD>
+                    <TD>{{ count[1] }}</TD>
+                </TR>
+                {% endfor %}</TBODY>
+            </TABLE>
+        {% include "footer.j2" %}
+    </BODY>
+</HTML>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   tt-app:
-    image: transit_tracker:1.0
+    image: transit_tracker:latest
     restart: always
     ports: 
       - '8000:8000'

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -10,32 +10,28 @@ class TestMainClass(unittest.TestCase):
         status_code = requests.get(url=BASE_URL).status_code
         self.assertEqual(status_code, 200)
 
-    def test_report(self):
-        status_code = requests.get(url=f"{BASE_URL}/report").status_code
-        self.assertEqual(status_code, 200)
-
     def test_add_ride(self):
         contents=f"car_no={TEST_CAR_NO}&line={TEST_RIDE_LINE}"
         headers = {'Content-Type': 'application/x-www-form-urlencoded'}
         status_code = requests.post(url=f"{BASE_URL}/add_ride", data=contents, headers=headers).status_code
         self.assertEqual(status_code, 200)
 
-    def test_scrub(self):
-        status_code = requests.get(url=f"{BASE_URL}/scrub").status_code
-        self.assertEqual(status_code, 200)
-
     def test_all_lines(self):
         status_code = requests.get(url=f"{BASE_URL}/lines").status_code
+        self.assertEqual(status_code, 200)
+    def test_a_ride(self):
+        status_code = requests.get(url=f"{BASE_URL}/rides/{TEST_CAR_NO}").status_code
         self.assertEqual(status_code, 200)
 
     def test_all_rides(self):
         status_code = requests.get(url=f"{BASE_URL}/rides").status_code
         self.assertEqual(status_code, 200)
 
-    def test_a_ride(self):
-        status_code = requests.get(url=f"{BASE_URL}/rides/{TEST_CAR_NO}").status_code
-        self.assertEqual(status_code, 200)
 
     def test_stock(self):
         status_code = requests.get(url=f"{BASE_URL}/stock").status_code
+        self.assertEqual(status_code, 200)
+
+    def test_scrub(self):
+        status_code = requests.get(url=f"{BASE_URL}/scrub").status_code
         self.assertEqual(status_code, 200)


### PR DESCRIPTION
- Added user-agent detection
- Fixes #37
- Deprecated `/report` for `/rides`
- Removed `/report` from `footer.j2`
- Removed `/report` from `tests/main_test.py`
- Updated all directives to return HTML or JSON based on user-agent
- Added templates for each HTML-based response
- Fixed trailing slash in URL for `/scrub`
- Added `push_to_github()` during `/scrub`
- Fixes #34
- Sending line longname to `/add_ride`
- Fixed #38
- Updated `README.md`